### PR TITLE
Fixes exporting of Image content type 

### DIFF
--- a/collective/jsonify/wrapper.py
+++ b/collective/jsonify/wrapper.py
@@ -351,6 +351,9 @@ class Wrapper(dict):
             fieldname = unicode(field.__name__)
             type_ = field.__class__.__name__
 
+            if type_[0] == '_' and type_.endswith('ExtensionField'):
+                type_ = type_[1: -len('ExtensionField')] + 'Field'
+
             if type_ in ['StringField', 'BooleanField', 'LinesField',
                     'IntegerField', 'TextField', 'SimpleDataGridField',
                     'FloatField', 'FixedPointField', 'TALESString',


### PR DESCRIPTION
For some reason, I met some images that where not being exported - I don't know if their
Storage mechanism had been changed in the site I was working with - but the "image" field itself was not being listed in the call made to pick all the object fields.

I resorted to iterating over the object's schemata to retrieve the fields - it works now.
