### PR TITLE
Support plone.app.collection QueryField

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 0.2 (2013-04-06)
 ----------------
 
+- Support p.a.collection QueryField.
+  [jone]
+
 - Add Blob fields support. Use specific methods to retrieve
   filename, content type and size.
   [gborelli]

--- a/collective/jsonify/wrapper.py
+++ b/collective/jsonify/wrapper.py
@@ -355,7 +355,8 @@ class Wrapper(dict):
                 'StringField', 'BooleanField', 'LinesField',
                 'IntegerField', 'TextField', 'SimpleDataGridField',
                 'FloatField', 'FixedPointField', 'TALESString',
-                'TALESLines', 'ZPTField', 'DataGridField', 'EmailField'
+                'TALESLines', 'ZPTField', 'DataGridField', 'EmailField',
+                'QueryField',
             ]
 
             if type_ in fieldnames:


### PR DESCRIPTION
By adding `QueryField` to the list of supported fields, plone.app.collection instances can be exported.

The exported data for the field is the internal structure of the field, a list of dicts with the constraints.
