### PR TITLE
Fixes to keep collective.jsonify working in Python2.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ only work with Plone 3.0 or higher (or not even with 3.0).
 ``collective.jsonify``'s only dependency is simplejson_. It can be installed in
 any Plone version as far back as:
 
-- Plone 2.5 (or probably even Plone 2.0, but not tested)
+- Plone 2.1 (or probably even Plone 2.0, but not tested)
 - Zope 2.6.4 (with CMF rather than Plone)
 - Python 2.2
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,11 @@
 Many packages that export data from Plone have complicated dependencies, and so
 only work with Plone 3.0 or higher (or not even with 3.0).
 ``collective.jsonify``'s only dependency is simplejson_. It can be installed in
-any Plone version, probably as far back as Plone 2.0 (not tested!).
+any Plone version as far back as:
+
+- Plone 2.5 (or probably even Plone 2.0, but not tested)
+- Zope 2.6.4 (with CMF rather than Plone)
+- Python 2.2
 
 The exported JSON_ is a collective.transmogrifier_ friendly format. Install
 ``collective.jsonify`` on a site you want to export from, and setup an import

--- a/collective/jsonify/export.py
+++ b/collective/jsonify/export.py
@@ -1,5 +1,6 @@
 """Add as external method. See install.rst in the documentation.
 """
+from __future__ import generators
 from collective.jsonify.methods import _clean_dict
 from collective.jsonify.wrapper import Wrapper
 from datetime import datetime

--- a/collective/jsonify/todo_zphoto.py
+++ b/collective/jsonify/todo_zphoto.py
@@ -66,7 +66,7 @@ class ZPhotoSlidesWrapper(BaseWrapper):
             self['lib'] = self.obj.lib
             self['convert'] = self.obj.convert
             self['use_http_cache'] = self.obj.use_http_cache
-        except Exception as e:
+        except Exception, e:
             raise Exception(
                 'Problems with %s: %s' %
                 (self.obj.absolute_url(), str(e)))

--- a/collective/jsonify/wrapper.py
+++ b/collective/jsonify/wrapper.py
@@ -395,7 +395,7 @@ class Wrapper(dict):
                 except AttributeError:
                     # maybe an int?
                     fname = unicode(fname)
-                except Exception as e:
+                except Exception, e:
                     raise Exception('problems with %s: %s' %
                                     (self.context.absolute_url(), str(e)))
 
@@ -578,7 +578,7 @@ class Wrapper(dict):
                     except AttributeError:
                         # maybe an int?
                         value = unicode(value)
-                    except Exception as e:
+                    except Exception, e:
                         raise Exception('problems with %s: %s' % (
                             self.context.absolute_url(), str(e))
                         )
@@ -644,7 +644,7 @@ class Wrapper(dict):
                     except AttributeError:
                         # maybe an int?
                         fname = unicode(fname)
-                    except Exception as e:
+                    except Exception, e:
                         raise Exception(
                             'problems with %s: %s' % (
                                 self.context.absolute_url(), str(e)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,6 +10,9 @@ options include:
 2. Use ``easy_install collective.jsonify`` or ``pip collective.jsonify`` which
    will also pull ``simplejson``.
 
+*Note: if you are working with python 2.2, then you will need to install a `tweaked 
+branch of simplejson <https://github.com/simplejson/simplejson/tree/python2.2>`_.*
+
 
 Then run your Zope instance, go to the Zope root and create the necessary
 External Methods.


### PR DESCRIPTION
@thet These are the fixes after your pull request #14.
I've had to revert the PEP8 "fix" of "Exception *as* e".

Can we keep it working as far back as Python 2.2 please?
Note that Python 2.1 would be near impossible because simplejson has always used generators (yield) which weren't available until 2.2 (via a future), so Python 2.2 is as far back as we need to go.

But thanks for doing the work on this - I might never have got there!

I've also updated the README to clarify what c.jsonify DOES work with. Can anyone confirm it works with Plone 2.0? I suspect since this works in Zope 2.6, then Plone 2.0 should be no trouble, but I'm not sure.
