### PR TITLE
Conditionally require simplejson

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Do not require simplejson if we already have the native json module
+  [ale-rt]
+
 - When doing an export with ``export_content`` and having constraints to skip
   items, still allow to walk into subitems of the skipped ones - except for
   skipped paths, where the whole path is skipped.

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,16 @@ else:
 
 version = '1.2.dev0'
 
+requirements = [
+    'setuptools',
+]
+
+# since Python 2.6 simplejson is not needed anymore
+try:
+    import json
+except ImportError:
+    requirements.append('simplejson')
+
 setup(
     name='collective.jsonify',
     version=version,
@@ -36,8 +46,5 @@ setup(
     namespace_packages=['collective'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=[
-        'setuptools',
-        'simplejson',
-    ],
+    install_requires=requirements,
 )


### PR DESCRIPTION
The library simplejson is not needed in recent Python version.

If we are not using a really version of Python,
we should not depend on simplejson.

Since version 2.6, Python ships with a json library.
The code already uses it in favour of simplejson.