### PR TITLE
Fixed value for unknown fields.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Fixed value for unknown fields.  The value was never calculated
+  fresh for these fields, so you got the value of the previous field.
+  Or you probably got a NameError if this was the first field.
+  [maurits]
+
 - Fix manifest
 - Added `CHANGES.rst merge=union` to `.gitattributes`
   [ale-rt]

--- a/collective/jsonify/wrapper.py
+++ b/collective/jsonify/wrapper.py
@@ -354,6 +354,10 @@ class Wrapper(dict):
 
             else:
                 # Just try to stringify value
+                try:
+                    value = field.getRaw(self.context)
+                except AttributeError:
+                    value = self._get_at_field_value(field)
                 self[unicode(fieldname)] = unicode(value)
 
     def get_references(self):


### PR DESCRIPTION
The value was never calculated fresh for these fields, so you got the value of the previous field.  Or you probably got a `NameError` if this was the first field.

I encountered this in a project that had a LocationField.  This was not recognised, so it got the value of the previous text field instead.