### PR TITLE
Export creation_date and modification_date for all objects, not only …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Changelog
 - Check if value exists on file like fields
   [agitator]
 
+- Export creation_date and modification_date for all objects, not only _is_cmf_only_obj.
+  For dexterity these values are not present in a schemata, so they are not included as part
+  of the normal schemata based dexterity export.
+  [sunew]
+
 
 1.3 (2017-12-21)
 ----------------

--- a/collective/jsonify/wrapper.py
+++ b/collective/jsonify/wrapper.py
@@ -745,7 +745,10 @@ class Wrapper(dict):
             self['modification_date'] = ''
 
     def get_basic_dates(self):
-        """
+        """ Dump creation and modification dates for items
+        that are not "cmf-only". For dexterity for instance, these
+        are not included in behaviors and so are not included in the
+        iteration over schematas and fields in get_dexterity_fields().
         """
         if self._is_cmf_only_obj():
             # then the dates are handled by get_zope_dublin_core,

--- a/collective/jsonify/wrapper.py
+++ b/collective/jsonify/wrapper.py
@@ -744,6 +744,21 @@ class Wrapper(dict):
         else:
             self['modification_date'] = ''
 
+    def get_basic_dates(self):
+        """
+        """
+        if self._is_cmf_only_obj():
+            # then the dates are handled by get_zope_dublin_core,
+            # so we do nothing.
+            return
+        # datetime fields
+        for field in ['creation_date', 'modification_date']:
+            val = getattr(self.context.aq_base, field, False)
+            if val:
+                self[field] = str(val)
+            else:
+                self[field] = ''
+
     def get_zope_cmfcore_fields(self):
         """If CMFCore is used in an old Zope site, then dump the fields we know
         about.


### PR DESCRIPTION
…_is_cmf_only_obj.

For dexterity these values are not present in a schemata, so they are not included as part
of the normal schemata based dexterity export.