### PR TITLE
Use self.decode method to get stringified field value when wrapping c…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ Changelog
   of the normal schemata based dexterity export.
   [sunew]
 
+- Use self.decode method to get stringified field value when wrapping content
+  for export.
+  [instification]
+
 
 1.3 (2017-12-21)
 ----------------

--- a/collective/jsonify/wrapper.py
+++ b/collective/jsonify/wrapper.py
@@ -404,7 +404,7 @@ class Wrapper(dict):
                     value = field.getRaw(self.context)
                 except AttributeError:
                     value = self._get_at_field_value(field)
-                self[unicode(fieldname)] = unicode(value)
+                self[unicode(fieldname)] = self.decode(value)
 
     def get_references(self):
         """AT references.

--- a/collective/jsonify/wrapper.py
+++ b/collective/jsonify/wrapper.py
@@ -404,7 +404,7 @@ class Wrapper(dict):
                     value = field.getRaw(self.context)
                 except AttributeError:
                     value = self._get_at_field_value(field)
-                self[unicode(fieldname)] = self.decode(value)
+                self[unicode(fieldname)] = self.decode(str(value))
 
     def get_references(self):
         """AT references.


### PR DESCRIPTION
…ontent for export

I was trying to export a site that had some unicode characters in an alt tag for a custom image type. The content was not getting exported due to it raising a UnicodeDecodeError (ascii can't decode byte...).

The Wrapper class already has a decode function which seems to handle this situation better and it's used elsewhere when decoding strings. So this PR just extends the use of self.decode to the catchall stringify instead of unicode().