### PR TITLE
- added new parameter `include_self` for including the root node of the…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- added new parameter `include_self` for include the root node of the export
+  within the export itself (needed for PloneFormGen to collective.easyform
+  migration)
+  [ajung]
 
 
 1.4 (2018-09-20)


### PR DESCRIPTION
This extension is needed for exporting a folderish object and all its subobjects that belong logically together. This is the case for PloneFormGen where you need to export the PFG instance and the subfield objects. Without this extension it would not be possible to export a single PFG instance completely. This is needed e.g. for migrating a PFG instance to collective.easyform.