### PR TITLE
Use objectValues() of folderish item. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Fix "AttributeError: get" that occurred with collective.jsonify 1.5 on Plone 2.1,
+  by using objectValues() to list items contained in a folder.
 
 1.5 (2020-08-21)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 - Fix "AttributeError: get" that occurred with collective.jsonify 1.5 on Plone 2.1,
   by using objectValues() to list items contained in a folder.
+  [rpijlman]
 
 1.5 (2020-08-21)
 ----------------

--- a/collective/jsonify/export.py
+++ b/collective/jsonify/export.py
@@ -295,9 +295,7 @@ def walk(folder, skip_callback=lambda item: False):
     :rtype: Plone context.
 
     """
-    for item_id in folder.objectIds():
-        item = folder.get(item_id)
-
+    for item in folder.objectValues():
         yield_item = True
         path = '/'.join(item.getPhysicalPath())
         if filter(lambda x: x in path, PATHS_TO_SKIP):


### PR DESCRIPTION
This works in very old Zopes (tested with Zope 2.8.7-final, python 2.3.5) as well as modern Zopes (tested with 2.13.30, python 2.7.16).

Fixes #48.